### PR TITLE
Include the already calculated actual percent.

### DIFF
--- a/lib/olde_code_finder/finder.rb
+++ b/lib/olde_code_finder/finder.rb
@@ -14,8 +14,9 @@ module OldeCodeFinder
       return if binary?
       total_lines = git_blame_output.size
       author_lines = git_blame_output.grep(/#{author}/).size
-      if (author_lines / total_lines.to_f) > (pctg.to_f / 100.0)
-        puts "More than #{pctg}% of #{file} was written by #{author}"
+      actual_percent = calculate_percent(author_lines, total_lines)
+      if actual_percent > pctg.to_f
+        puts "More than #{pctg}% of #{file} was written by #{author} (#{actual_percent}%)"
       end
     end
 
@@ -25,12 +26,17 @@ module OldeCodeFinder
       date_threshold = (Date.today - (years_ago*365))
       total_lines = git_blame_output.size
       older_lines = git_blame_output.select {|line| Date.strptime(line.match(/.*(\d{4}-\d{2}-\d{2})/)[1]) < date_threshold }.size
-      if (older_lines / total_lines.to_f) > (pctg.to_f / 100.0)
-        puts "More than #{pctg}% of #{file} was written more than #{years_ago} years ago"
+      actual_percent = calculate_percent(older_lines, total_lines)
+      if actual_percent > pctg.to_f
+        puts "More than #{pctg}% of #{file} was written more than #{years_ago} years ago (#{actual_percent}%)"
       end
     end
 
     private
+
+    def calculate_percent(matched_lines, total_lines)
+      ((matched_lines / total_lines.to_f) * 100).round(2)
+    end
 
     def binary?
       `git diff --numstat 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD -- #{file}`.match(/^-\t-\t/)


### PR DESCRIPTION
If you have many files that match the threshold percent, printing the actual percent can help narrow your search.

For example:
  `More than 40% of app/models/user.rb was written more than 3 years ago (93.94%)`
